### PR TITLE
Fixed Website C# & Java Markdown Highlight

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -168,7 +168,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
-        additionalLanguages: ['csharp', 'java']
+        additionalLanguages: ['csharp', 'java', 'kotlin', 'rust']
       },
       // https://docusaurus.io/docs/search#using-algolia-docsearch
       algolia: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -168,6 +168,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages: ['csharp', 'java']
       },
       // https://docusaurus.io/docs/search#using-algolia-docsearch
       algolia: {

--- a/solutions/1400-1499/1491-average-salary-excluding-the-minimum-and-maximum-salary-easy.md
+++ b/solutions/1400-1499/1491-average-salary-excluding-the-minimum-and-maximum-salary-easy.md
@@ -63,7 +63,7 @@ func average(salary []int) float64 {
 
 <SolutionAuthor name="@wingkwong"/>
 
-```rs
+```rust
 use std::cmp;
 
 impl Solution {

--- a/solutions/1500-1599/1523-count-odd-numbers-in-an-interval-range-easy.md
+++ b/solutions/1500-1599/1523-count-odd-numbers-in-an-interval-range-easy.md
@@ -52,7 +52,7 @@ func countOdds(low int, high int) int {
 
 <SolutionAuthor name="@wingkwong"/>
 
-```rs
+```rust
 impl Solution {
     pub fn count_odds(low: i32, high: i32) -> i32 {
         let mut ans = 0;
@@ -78,7 +78,7 @@ func countOdds(low int, high int) int {
 
 <SolutionAuthor name="@wingkwong"/>
 
-```rs
+```rust
 impl Solution {
     pub fn count_odds(low: i32, high: i32) -> i32 {
         return (high + 1) / 2 - (low / 2);


### PR DESCRIPTION
Prism's default language highlight doesn't include C# and Java.
I edited docusaurus.config.js and fixed this issue.
