### PR TITLE
Update 0003-longest-substring-without-repeating-characters-medium.md

### DIFF
--- a/solutions/0000-0099/0003-longest-substring-without-repeating-characters-medium.md
+++ b/solutions/0000-0099/0003-longest-substring-without-repeating-characters-medium.md
@@ -110,6 +110,33 @@ var lengthOfLongestSubstring = function (s) {
 };
 ```
 </TabItem>
+  
+<TabItem value="python" label="python">
+<SolutionAuthor name="@mrsourav1"/>
+
+```python
+class Solution:
+  def lengthOfLongestSubstring(self, s: str) -> int:
+    hashset = set() 
+    l = 0 #first pointer
+    res = 0
+    for r in range(len(s)):  #r working as second pointer
+      while s[r] in hashset:
+        hashset.remove(s[l])
+        l += 1
+      hashset.add(s[r])
+      res = max(res,r-l+1)
+    return res
+#lets say our s = "pwwkew" now our l pointer pointing to l and our r pointer pointing to 
+# r and we're at point p right now and p not in hashset so we'll add p to the hashset
+# and now p in hashset and res will be 1 remember we're in for loop so my r pointer is at w
+# as per our example and w is not in hashset so we will add w in hashset and now our res is 2
+# so now we are at index 2 which is w again but w in hashset so we will try to remove w so what 
+# we will do is our l pointer is at index 0 so we will remove p first and then w now we have only
+# w in our hashset and but our res will be 2 because we're using max function and updating our result
+# so our result will not update and so on... hope you got the idea how this algorithm working.
+```
+</TabItem>  
 </Tabs>
 
 


### PR DESCRIPTION
add python solution with good example .

## Change Summary

Provide summary of changes with issue number if any.

## Checklist

**If you haven't fulfilled the below requirements or even delete the entire checklist, your PR won't be reviewed and will be closed without notice.**

### General 

- [ ] This Pull Request is all my own work. (You'll be blacklisted if you are caught for plagiarism.)
- [ ] I've read [CONTRIBUTING.md](https://github.com/wingkwong/leetcode-the-hard-way/blob/main/CONTRIBUTING.md)
- [ ] I've applied LaTex for all variables, formulas and time / space complexity instead of using backticks
- [ ] I've started the app locally and verified all the content and all links (if applicable) are accessible correctly
- [ ] I've included Complexity Analysis (Time Complexity & Space Complexity).
- [ ] I've written my explanation well and it is easy to understand for beginners

### Tutorial

- [ ] I've read and followed the [Tutorial Template](https://github.com/wingkwong/leetcode-the-hard-way/blob/main/CONTRIBUTING.md#tutorial-template)
- [ ] I've explained my topic well with 2 - 3 LC problems and no external problems are used. 
- [ ] I've provided the full working solutions to the problems used in this tutorial.
- [ ] I've provided suggested problems at the end with the given format. See [here](https://raw.githubusercontent.com/wingkwong/leetcode-the-hard-way/main/tutorials/math/number-theory/binary-exponentiation.md) as an example. If the target solution is not available, leave `solutionLink` blank.
- [ ] I've given credits / references if I use external resources. (For an image, give credit under it. Otherwise, add a new section called References at the end (after Suggested Problems).)

### Solutions

- [ ] I've read and followed the [Solution Template](https://github.com/wingkwong/leetcode-the-hard-way/blob/main/CONTRIBUTING.md#solution-template)
- [ ] I've formatted my code well with [K&R Coding style](https://gist.github.com/jesseschalken/0f47a2b5a738ced9c845#why-kr)
- [ ] I've confirmed that comments are put above each line rather than writing on the same line.
- [ ] I've included a meaningful approach name for my solution. e.g. `## Approach 1: Two Pointers`.